### PR TITLE
Fix `Formatter.functionName` TypeError for arrow functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,12 @@ Formatter.functionName = function functionName(f) {
   if(f.name) {
     return f.name;
   }
-  var name = f.toString().match(functionNameRE)[1];
+  var matches = f.toString().match(functionNameRE);
+  if (matches === null) {
+    // `functionNameRE` doesn't match arrow functions.
+    return '';
+  }
+  var name = matches[1];
   return name;
 };
 


### PR DESCRIPTION
When called with an arrow function as parameter it threw a TypeError.

    Formatter.functionName((a) => a)

The regular expression that matches the name from the function
declaration string doesn't care about arrow function syntax, thus it
didn't match anything, `.match` returned `null` and `null[1]` threw:

    TypeError: Cannot read property '1' of null